### PR TITLE
`cd $CDIR` before copying prerun files

### DIFF
--- a/{{cookiecutter.project_repo_name}}/build.sh
+++ b/{{cookiecutter.project_repo_name}}/build.sh
@@ -31,10 +31,8 @@ build() {
   rm -rf $build_dir
   mkdir -p $build_dir
 
-  for f in *prerun.sh *pluginrc.*
-  do
-      cp $CDIR/$f $build_dir/
-  done
+  cd $CDIR
+  cp *prerun.sh *pluginrc.* $build_dir/
 
   cd $build_dir
 


### PR DESCRIPTION
Fixes the problem of the script pulling prerun files from wherever it is invoked.
